### PR TITLE
Corrected licensing mistake

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
         <ul>
           <li><a href="https://cloud.partipirate.org/index.php/s/Y5Y8ZQzFNeJwxBp">Statutes</a></li>
         </ul>
-        <p style="max-width:25rem"> This page is licensed under the GNU General Public License v3, the source code is available on <a href=https://github.com/Fhavlonir/YPE-placeholder>Github</a>
+        <p style="max-width:25rem"> This page is licensed under the GNU Affero General Public License v3, the source code is available on <a href=https://github.com/Fhavlonir/YPE-placeholder>Github</a>
       </div>
     </div>
 


### PR DESCRIPTION
The repo is licensed under the AGPL, not the GPL. Removed legal ambiguity :)